### PR TITLE
Extend daily tracker through October 31

### DIFF
--- a/probabilities.json
+++ b/probabilities.json
@@ -140,6 +140,118 @@
       "end_today_prob": 1,
       "shutdown_continues_prob": 0.2,
       "watch": "If still ongoing, severe disruption prompts emergency talks"
+    },
+    {
+      "day": 15,
+      "date": "2025-10-16",
+      "end_today_prob": 0.8,
+      "shutdown_continues_prob": 0.15,
+      "watch": "Backpay bill negotiations; OMB contingency updates"
+    },
+    {
+      "day": 16,
+      "date": "2025-10-17",
+      "end_today_prob": 0.7,
+      "shutdown_continues_prob": 0.12,
+      "watch": "FAA staffing strain; moderate coalition press conference"
+    },
+    {
+      "day": 17,
+      "date": "2025-10-18",
+      "end_today_prob": 0.6,
+      "shutdown_continues_prob": 0.1,
+      "watch": "Markets watching T-bill auctions; governors escalate push"
+    },
+    {
+      "day": 18,
+      "date": "2025-10-19",
+      "end_today_prob": 0.5,
+      "shutdown_continues_prob": 0.08,
+      "watch": "Weekend pressure; small business relief demands"
+    },
+    {
+      "day": 19,
+      "date": "2025-10-20",
+      "end_today_prob": 0.45,
+      "shutdown_continues_prob": 0.065,
+      "watch": "Agency overtime liabilities; CR text revisions"
+    },
+    {
+      "day": 20,
+      "date": "2025-10-21",
+      "end_today_prob": 0.4,
+      "shutdown_continues_prob": 0.055,
+      "watch": "Debt limit parallels; bipartisan lunch meeting"
+    },
+    {
+      "day": 21,
+      "date": "2025-10-22",
+      "end_today_prob": 0.35,
+      "shutdown_continues_prob": 0.045,
+      "watch": "Humanitarian aid logjams; Senate procedural maneuvers"
+    },
+    {
+      "day": 22,
+      "date": "2025-10-23",
+      "end_today_prob": 0.3,
+      "shutdown_continues_prob": 0.035,
+      "watch": "Federal employee rally; continuing resolution amendments"
+    },
+    {
+      "day": 23,
+      "date": "2025-10-24",
+      "end_today_prob": 0.25,
+      "shutdown_continues_prob": 0.028,
+      "watch": "CR fallback scoring; leadership approval dips"
+    },
+    {
+      "day": 24,
+      "date": "2025-10-25",
+      "end_today_prob": 0.22,
+      "shutdown_continues_prob": 0.022,
+      "watch": "Defense readiness hearings; credit rating warnings"
+    },
+    {
+      "day": 25,
+      "date": "2025-10-26",
+      "end_today_prob": 0.2,
+      "shutdown_continues_prob": 0.018,
+      "watch": "Weekend governor summit; airline disruption risk"
+    },
+    {
+      "day": 26,
+      "date": "2025-10-27",
+      "end_today_prob": 0.18,
+      "shutdown_continues_prob": 0.014,
+      "watch": "Appropriations staff marathon; FEMA depletion"
+    },
+    {
+      "day": 27,
+      "date": "2025-10-28",
+      "end_today_prob": 0.15,
+      "shutdown_continues_prob": 0.011,
+      "watch": "Contractor insolvency risk; bipartisan pressure cooker"
+    },
+    {
+      "day": 28,
+      "date": "2025-10-29",
+      "end_today_prob": 0.12,
+      "shutdown_continues_prob": 0.009,
+      "watch": "State aid delays; national parks closure backlash"
+    },
+    {
+      "day": 29,
+      "date": "2025-10-30",
+      "end_today_prob": 0.1,
+      "shutdown_continues_prob": 0.007,
+      "watch": "Month-end payroll missed; emergency appropriation talk"
+    },
+    {
+      "day": 30,
+      "date": "2025-10-31",
+      "end_today_prob": 0.08,
+      "shutdown_continues_prob": 0.005,
+      "watch": "Halloween deadline theatrics; credit downgrade fears"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extend the daily shutdown probability tracker entries to cover dates through October 31, including ongoing watch highlights

## Testing
- `node -e "const data=require('./probabilities.json'); console.log(data.daily_tracker.length);"`


------
https://chatgpt.com/codex/tasks/task_e_68dee7d038d8832d8ff985f2f023a7a9